### PR TITLE
onderlijn profiel indien geselecteerd

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,12 +8,11 @@
 /*
  Mui customization
 */
-.MuiButton-root.selected{
+.MuiButton-root.selected, .MuiTypography-root.selected {
   border-bottom: thin green solid;
   background-color: inherit;
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
-
 }
 
 .MuiTypography-root.MuiTypography-h4{

--- a/src/App.css
+++ b/src/App.css
@@ -2,17 +2,19 @@
   max-width: 1280px;
   margin: 0 auto;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-
 }
 
 /*
  Mui customization
 */
-.MuiButton-root.selected, .MuiTypography-root.selected {
-  border-bottom: thin green solid;
-  background-color: inherit;
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
+.MuiAppBar-root {
+  button.MuiButton-root.selected,
+  p.MuiTypography-root.selected {
+    border-bottom: thin green solid;
+    background-color: inherit;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+  }
 }
 
 .MuiTypography-root.MuiTypography-h4{

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -156,17 +156,17 @@ function Header() {
       opgeslagenActieveHulpvragerId === undefined
         ? dataGebruiker.gebruiker
         : Number(dataGebruiker.gebruiker?.id) ===
-            Number(opgeslagenActieveHulpvragerId)
+          Number(opgeslagenActieveHulpvragerId)
           ? dataGebruiker.gebruiker
           : (dataGebruiker.hulpvragers as Gebruiker[]).find(
-              (hv) => Number(hv.id) === Number(opgeslagenActieveHulpvragerId),
-            );
+            (hv) => Number(hv.id) === Number(opgeslagenActieveHulpvragerId),
+          );
 
     const opgeslagenGekozenPeriodeId = localStorage.getItem('gekozenPeriode');
     const opgeslagenGekozenPeriode = opgeslagenGekozenPeriodeId
       ? (opgeslagenActieveHulpvrager?.periodes as Periode[]).find(
-          (periode) => periode.id === Number(opgeslagenGekozenPeriodeId),
-        )
+        (periode) => periode.id === Number(opgeslagenGekozenPeriodeId),
+      )
       : undefined;
 
     let nieuweActieveHulpvrager, nieuweGekozenPeriode;
@@ -330,7 +330,8 @@ function Header() {
                   }}
                 >
                   <Typography
-                    sx={{ my: 'auto', mr: { xs: '3px', md: '10px' } }}
+                    sx={{ p: '6px', my: 'auto', mr: { xs: '3px', md: '10px' } }}
+                    className={currentPage.toLowerCase() === 'profiel' ? 'selected' : ''}
                   >
                     {actieveHulpvrager?.bijnaam}
                   </Typography>


### PR DESCRIPTION
Een oefening om ook weer een pull request te maken: als het profiel als pagina is geselecteerd (door op de bijnaam van de gekozen hulpvrager te klikken) wordt deze nu ook onderlijnd.

De css is nu niet beperkt tot de Header, klopt dat? Is dat iets dat we zouden moeten aanpassen? Wat is best practice?